### PR TITLE
Allow overiding of namespace for a generated sdk

### DIFF
--- a/generator/sdkifier
+++ b/generator/sdkifier
@@ -9,6 +9,7 @@ ini_set("memory_limit", "256M");
 $sdkOutputPath = isset($argv[1]) ? $argv[1] : APP_ROOT . "/vendor/segura/lib" . strtolower(APP_NAME) . "/";
 $appName       = isset($argv[2]) ? $argv[2] : null;
 $remoteApiUri  = isset($argv[3]) ? $argv[3] : null;
+$namespace     = isset($argv[4]) ? $argv[4] : "Gone";
 
 if(defined("APP_CORE_NAME")) {
     $scope = APP_CORE_NAME;
@@ -19,7 +20,7 @@ if(defined("APP_CORE_NAME")) {
     $scope = Gone\AppCore\App::class;
 
     define("APP_NAME", $appName);
-    define("APP_CORE_NAME", "Gone\\{$appName}");
+    define("APP_CORE_NAME", "{$namespace}\\{$appName}");
 }
 
 try {


### PR DESCRIPTION
Allow the namespace to be overridden in the command to generate an sdk
Default back to Gone if not specified.